### PR TITLE
feat: Implement subscription link switching

### DIFF
--- a/service/hiddify
+++ b/service/hiddify
@@ -20,7 +20,7 @@ SUB_URL="https://raw.githubusercontent.com/tvccccc/TVCCCC/refs/heads/main/subscr
 Enable_OVPN=false # This script part focuses on non-OVPN part. OVPN watchdog would need similar changes.
 
 # CRON_JOB_OLD="18,48 * * * * /etc/init.d/hiddify restart" # Old cron job
-CRON_JOB_NEW="0 * * * * /etc/init.d/hiddify update_config" # New cron job
+CRON_JOB_NEW="0 */12 * * * /root/update_subscriptions.sh && /etc/init.d/hiddify update_config" # New cron job
 
 LIVE_CONFIG_FILE="/root/hiddify-sub"
 WATCHDOG_SCRIPT_NAME="hiddify_watchdog.sh" # Assuming this is the non-OpenVPN watchdog
@@ -81,6 +81,9 @@ remove_cron_job() {
 start() {
     echo "Starting Hiddify service..."
     
+    cp -f /etc/init.d/update_subscriptions.sh /root/update_subscriptions.sh
+    chmod +x /root/update_subscriptions.sh
+
     if [ ! -f "$SERVICE_DIR/HiddifyCli" ]; then
         download_and_extract || return 1
     fi
@@ -187,14 +190,22 @@ restart() {
 
 update_config() {
     echo "Attempting to trigger configuration update for Hiddify..."
+
+    # Run the subscription update script
+    /root/update_subscriptions.sh
+
+    # Read the best URL from the state file
+    if [ -f "/tmp/hiddify_current_sub_url" ]; then
+        export SUB_URL=$(cat "/tmp/hiddify_current_sub_url")
+    else
+        echo "Error: State file not found. Cannot determine subscription URL."
+        return
+    fi
+
     local watchdog_pid
-    # Find the PID of the correct watchdog script
-    # We use pgrep -f to match the full path, avoiding issues with other scripts named similarly
     watchdog_pid=$(pgrep -f "/root/$WATCHDOG_SCRIPT_NAME")
 
     if [ -n "$watchdog_pid" ]; then
-        # Send SIGUSR1 signal to the watchdog script
-        # Handle cases where multiple PIDs might be found (though unlikely for nohup'd script)
         for pid in $watchdog_pid; do
             echo "Sending SIGUSR1 to $WATCHDOG_SCRIPT_NAME (PID: $pid)"
             kill -USR1 "$pid"

--- a/update_subscriptions.sh
+++ b/update_subscriptions.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+# List of subscription links
+SUB_URLS=(
+    "https://raw.githubusercontent.com/tvccccc/TVCCCC/refs/heads/main/subscriptions/xray/normal/mix"
+    "http://router.freehost.io/github/mix.txt"
+    "https://raw.githubusercontent.com/PacketCipher/TVC/refs/heads/main/subscriptions/xray/normal/mix"
+)
+
+# State file to store the current subscription URL
+STATE_FILE="/tmp/hiddify_current_sub_url"
+
+# Temporary file to store the downloaded content
+TMP_FILE="/tmp/hiddify_sub_content"
+
+# Get the current subscription URL
+if [ -f "$STATE_FILE" ]; then
+    CURRENT_SUB_URL=$(cat "$STATE_FILE")
+else
+    CURRENT_SUB_URL=${SUB_URLS[0]}
+fi
+
+# Function to check if a URL is available
+is_available() {
+    curl -L --output /dev/null --silent --head --fail "$1"
+}
+
+# Function to get the content of a URL
+get_content() {
+    curl -L --silent "$1"
+}
+
+# Find the best subscription link
+BEST_SUB_URL=""
+for url in "${SUB_URLS[@]}"; do
+    if is_available "$url"; then
+        CONTENT=$(get_content "$url")
+        if [ -n "$CONTENT" ]; then
+            if [ "$url" != "$CURRENT_SUB_URL" ]; then
+                echo "$CONTENT" > "$TMP_FILE"
+                if ! cmp -s "$TMP_FILE" <(get_content "$CURRENT_SUB_URL"); then
+                    BEST_SUB_URL=$url
+                    break
+                fi
+            else
+                BEST_SUB_URL=$url
+                break
+            fi
+        fi
+    fi
+done
+
+# If no new link is found, use the current one if it's still available
+if [ -z "$BEST_SUB_URL" ] && is_available "$CURRENT_SUB_URL"; then
+    BEST_SUB_URL=$CURRENT_SUB_URL
+fi
+
+# If a best link is found, update the state file
+if [ -n "$BEST_SUB_URL" ]; then
+    echo "$BEST_SUB_URL" > "$STATE_FILE"
+fi
+
+# Clean up temporary files
+rm -f "$TMP_FILE"


### PR DESCRIPTION
This commit introduces a new script, `update_subscriptions.sh`, which dynamically selects the best subscription link from a predefined list. The selection is based on link availability and content freshness.

The `service/hiddify` script has been modified to use the new script. The cron job is now configured to run the update script every 12 hours.

This change addresses the issue of subscription link failure due to severe filtering by introducing a backup mechanism. The solution is designed to be lightweight and memory-efficient, making it suitable for low-RAM devices like routers.