### PR TITLE
fix: Use space-separated strings instead of arrays

### DIFF
--- a/service/hiddify
+++ b/service/hiddify
@@ -62,12 +62,9 @@ download_initial_config() {
             echo "Primary subscription link failed. Trying backup links..."
 
             # The list of backup URLs should be the same as in update_subscriptions.sh
-            local backup_urls=(
-                "http://router.freehost.io/github/mix.txt"
-                "https://raw.githubusercontent.com/PacketCipher/TVC/refs/heads/main/subscriptions/xray/normal/mix"
-            )
+            local backup_urls="http://router.freehost.io/github/mix.txt https://raw.githubusercontent.com/PacketCipher/TVC/refs/heads/main/subscriptions/xray/normal/mix"
 
-            for url in "${backup_urls[@]}"; do
+            for url in $backup_urls; do
                 echo "Trying backup link: $url"
                 curl -L -o "$LIVE_CONFIG_FILE" "$url"
                 if [ -s "$LIVE_CONFIG_FILE" ]; then

--- a/update_subscriptions.sh
+++ b/update_subscriptions.sh
@@ -1,11 +1,7 @@
 #!/bin/sh
 
 # List of subscription links
-SUB_URLS=(
-    "https://raw.githubusercontent.com/tvccccc/TVCCCC/refs/heads/main/subscriptions/xray/normal/mix"
-    "http://router.freehost.io/github/mix.txt"
-    "https://raw.githubusercontent.com/PacketCipher/TVC/refs/heads/main/subscriptions/xray/normal/mix"
-)
+SUB_URLS="https://raw.githubusercontent.com/tvccccc/TVCCCC/refs/heads/main/subscriptions/xray/normal/mix http://router.freehost.io/github/mix.txt https://raw.githubusercontent.com/PacketCipher/TVC/refs/heads/main/subscriptions/xray/normal/mix"
 
 # State file to store the current subscription URL
 STATE_FILE="/tmp/hiddify_current_sub_url"
@@ -32,7 +28,7 @@ get_content() {
 
 # Find the best subscription link
 BEST_SUB_URL=""
-for url in "${SUB_URLS[@]}"; do
+for url in $SUB_URLS; do
     if is_available "$url"; then
         CONTENT=$(get_content "$url")
         if [ -n "$CONTENT" ]; then


### PR DESCRIPTION
This commit fixes a syntax error that occurred when running the scripts on an OpenWrt system, which uses the `ash` shell. The `ash` shell does not support arrays, so I have replaced them with space-separated strings.

I modified the following files:
- `service/hiddify`: The `backup_urls` array has been replaced with a space-separated string.
- `update_subscriptions.sh`: The `SUB_URLS` array has been replaced with a space-separated string.