### PR TITLE
feat: Implement subscription link switching and cleanup

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -21,6 +21,7 @@ rm -f /root/hiddify-conf.json
 rm -f /root/hiddify-openvpn-conf.json
 rm -f /root/hiddify_watchdog.sh
 rm -f /root/hiddify_openvpn_watchdog.sh
+rm -f /root/update_subscriptions.sh
 rm -f /root/hiddify-sub # Live configuration file
 rm -rf /root/openvpn/
 


### PR DESCRIPTION
This commit introduces a new script, `update_subscriptions.sh`, which dynamically selects the best subscription link from a predefined list. The selection is based on link availability and content freshness.

The `service/hiddify` script has been modified to use the new script. The cron job is now configured to run the update script every 12 hours.

The `download_initial_config` function in `service/hiddify` has been updated to iterate through the backup links if the default link is unavailable during the initial setup.

The `update_subscriptions.sh` file has been added to the `cleanup.sh` script to ensure it is removed when the cleanup script is executed.

This change addresses the issue of subscription link failure due to severe filtering by introducing a backup mechanism. The solution is designed to be lightweight and memory-efficient, making it suitable for low-RAM devices like routers.