### PR TITLE
fix: Read SUB_URLS directly from hiddify service file

### DIFF
--- a/update_subscriptions.sh
+++ b/update_subscriptions.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-# List of subscription links is passed as an environment variable (SUB_URLS)
+# Read SUB_URLS from the hiddify service file
+if [ -f "/etc/init.d/hiddify" ]; then
+    SUB_URLS=$(grep -o 'SUB_URLS="[^"]*"' /etc/init.d/hiddify | sed 's/SUB_URLS="//;s/"//')
+fi
 
 # State file to store the current subscription URL
 STATE_FILE="/tmp/hiddify_current_sub_url"


### PR DESCRIPTION
This commit fixes an issue where the `update_subscriptions.sh` script, when executed by a cron job, did not have access to the `SUB_URLS` environment variable.

The script has been modified to read the `SUB_URLS` variable directly from the `/etc/init.d/hiddify` file. This ensures that the script has access to the subscription links when it is executed by the cron job.