### PR TITLE
Refactor: Decouple subscription URLs into a configuration file

### DIFF
--- a/hiddify_urls.conf
+++ b/hiddify_urls.conf
@@ -1,0 +1,1 @@
+SUB_URLS="http://router.freehost.io/github/mix.txt https://raw.githubusercontent.com/tvccccc/TVCCCC/refs/heads/main/subscriptions/xray/normal/mix https://raw.githubusercontent.com/PacketCipher/TVC/refs/heads/main/subscriptions/xray/normal/mix"

--- a/service/hiddify
+++ b/service/hiddify
@@ -11,7 +11,9 @@ HIDDIFY_URL="https://github.com/NullRoute-Lab/hiddify-core/releases/download/v1.
 # HIDDIFY_URL="https://github.com/NullRoute-Lab/hiddify-core/releases/download/v1.0.1/hiddify-cli-linux-arm64.tar.gz"
 
 
-SUB_URLS="http://router.freehost.io/github/mix.txt https://raw.githubusercontent.com/tvccccc/TVCCCC/refs/heads/main/subscriptions/xray/normal/mix https://raw.githubusercontent.com/PacketCipher/TVC/refs/heads/main/subscriptions/xray/normal/mix"
+if [ -f "/root/hiddify_urls.conf" ]; then
+    . /root/hiddify_urls.conf
+fi
 SUB_URL=$(echo "$SUB_URLS" | cut -d' ' -f1)
 
 # Modify OpenVPN to be enabled or not

--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,7 @@ opkg install coreutils-nohup curl wget jq
 # Copy configuration and watchdog script, overwriting if they exist
 cp -f hiddify-conf.json /root/hiddify-conf.json
 cp -f hiddify-openvpn-conf.json /root/hiddify-openvpn-conf.json
+cp -f hiddify_urls.conf /root/hiddify_urls.conf
 cp -f hiddify_watchdog.sh /root/hiddify_watchdog.sh
 cp -f hiddify_openvpn_watchdog.sh /root/hiddify_openvpn_watchdog.sh
 cp -f -R openvpn /root/openvpn

--- a/update_subscriptions.sh
+++ b/update_subscriptions.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
-# Read SUB_URLS from the hiddify service file
-if [ -f "/etc/init.d/hiddify" ]; then
-    SUB_URLS=$(grep -o 'SUB_URLS="[^"]*"' /etc/init.d/hiddify | sed 's/SUB_URLS="//;s/"//')
+if [ -f "/root/hiddify_urls.conf" ]; then
+    . /root/hiddify_urls.conf
 fi
 
 # State file to store the current subscription URL


### PR DESCRIPTION
This commit refactors the way subscription URLs are managed in the hiddify project.

Previously, the SUB_URLS variable was hardcoded in the `service/hiddify` script and read directly by `update_subscriptions.sh`. This created a tight coupling between the configuration and the application logic.

This commit introduces a new configuration file, `hiddify_urls.conf`, to store the subscription URLs. The `setup.sh`, `update_subscriptions.sh`, and `service/hiddify` scripts have been updated to use this new configuration file.

This change makes the configuration more robust and easier to maintain.